### PR TITLE
Feature/467574 añadir gesto refrescar

### DIFF
--- a/AndroidProject/app/build.gradle
+++ b/AndroidProject/app/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.test.espresso:espresso-idling-resource:3.4.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:3.+"
     testImplementation 'androidx.test:core:1.0.0'

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/convenios/ConveniosView.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/convenios/ConveniosView.java
@@ -13,6 +13,8 @@ import android.widget.ListView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 
 import es.unican.is.appgasolineras.R;
 import es.unican.is.appgasolineras.activities.toolbar.BarraHerramientasView;
@@ -27,6 +29,7 @@ public class ConveniosView extends AppCompatActivity implements  IConveniosContr
     private IConveniosContract.Presenter presenter;
 
     private BarraHerramientasView barraHerramientasView;
+    private SwipeRefreshLayout swipeRefreshLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,6 +41,15 @@ public class ConveniosView extends AppCompatActivity implements  IConveniosContr
 
         presenter = new ConveniosPresenter(this);
         presenter.init();
+        swipeRefreshLayout = findViewById(R.id.swiperefreshConvenio);
+        swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                presenter.init();
+                swipeRefreshLayout.setRefreshing(false);
+            }
+        });
+
     }
 
     /*

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/historialRepostajes/HistorialRepostajesView.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/historialRepostajes/HistorialRepostajesView.java
@@ -10,6 +10,9 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+//import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import java.util.List;
 import es.unican.is.appgasolineras.R;
 import es.unican.is.appgasolineras.activities.main.MainView;
@@ -21,6 +24,7 @@ public class HistorialRepostajesView extends AppCompatActivity implements IHisto
 
     private BarraHerramientasView barraHerramientasView;
     private IHistorialRepostajesContract.Presenter presenter;
+    private SwipeRefreshLayout swipeRefreshLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -35,6 +39,16 @@ public class HistorialRepostajesView extends AppCompatActivity implements IHisto
 
         TextView tv = findViewById(R.id.tvHistorialRepostajeMessage);
         tv.setText("HISTORIAL REPOSTAJES");
+
+
+        swipeRefreshLayout = findViewById(R.id.swiperefreshRepostaje);
+        swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                presenter.init();
+                swipeRefreshLayout.setRefreshing(false);
+            }
+        });
     }
 
     /*

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/main/MainView.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/main/MainView.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 
 import android.Manifest;
@@ -42,6 +43,7 @@ public class MainView extends AppCompatActivity implements IMainContract.View {
     private FusedLocationProviderClient fusedLocationClient;
     private Location currentLocation;
     private static int debug = 0;
+    private SwipeRefreshLayout swipeRefreshLayout;
     /*
     Activity lifecycle methods
      */
@@ -65,6 +67,14 @@ public class MainView extends AppCompatActivity implements IMainContract.View {
 
         presenter = new MainPresenter(this, prefs);
         presenter.init();
+        swipeRefreshLayout = findViewById(R.id.swiperefresh);
+        swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                presenter.init();
+                swipeRefreshLayout.setRefreshing(false);
+            }
+        });
         this.init();
     }
 

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/main/MainView.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/main/MainView.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.swiperefreshlayout.*;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/toolbar/BarraHerramientasPresenter.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/toolbar/BarraHerramientasPresenter.java
@@ -17,11 +17,6 @@ public class BarraHerramientasPresenter implements IBarraHerramientasContract.Pr
     }
 
     @Override
-    public void onRefreshClicked() {
-        view.getActivity().recreate();
-    }
-
-    @Override
     public void onConveniosClicked() {
         view.openConveniosView();
     }

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/toolbar/BarraHerramientasView.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/toolbar/BarraHerramientasView.java
@@ -122,9 +122,6 @@ public class BarraHerramientasView extends AppCompatActivity implements IBarraHe
             case R.id.menuInfo:
                 presenter.onInfoClicked();
                 return true;
-            case R.id.menuRefresh:
-                presenter.onRefreshClicked();
-                return true;
             case R.id.menuConvenios:
                 presenter.onConveniosClicked();
                 return true;
@@ -173,26 +170,26 @@ public class BarraHerramientasView extends AppCompatActivity implements IBarraHe
 
     @Override
     public void showOrdenarDistanciaSelected() {
-        menu.getItem(4).setIcon(activity.getDrawable(R.drawable.location_selected_32));
-        menu.getItem(4).setTitle("DistanciaMarcada");
+        menu.getItem(3).setIcon(activity.getDrawable(R.drawable.location_selected_32));
+        menu.getItem(3).setTitle("DistanciaMarcada");
 
     }
 
     @Override
     public void showOrdenarPrecioAscSelected() {
-        menu.getItem(5).setIcon(activity.getDrawable(R.drawable.low_price_selected_57));
-        menu.getItem(5).setTitle("PrecioMarcado");
+        menu.getItem(4).setIcon(activity.getDrawable(R.drawable.low_price_selected_57));
+        menu.getItem(4).setTitle("PrecioMarcado");
     }
 
     @Override
     public void showOrdenarDistanciaDeselected() {
-        menu.getItem(4).setIcon(activity.getDrawable(R.drawable.location_32));
-        menu.getItem(4).setTitle("DistanciaSinMarcar");
+        menu.getItem(3).setIcon(activity.getDrawable(R.drawable.location_32));
+        menu.getItem(3).setTitle("DistanciaSinMarcar");
     }
 
     @Override
     public void showOrdenarPrecioAscDeselected() {
-        menu.getItem(5).setIcon(activity.getDrawable(R.drawable.low_price_57));
-        menu.getItem(5).setTitle("PrecioNoMarcado");
+        menu.getItem(4).setIcon(activity.getDrawable(R.drawable.low_price_57));
+        menu.getItem(4).setTitle("PrecioNoMarcado");
     }
 }

--- a/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/toolbar/IBarraHerramientasContract.java
+++ b/AndroidProject/app/src/main/java/es/unican/is/appgasolineras/activities/toolbar/IBarraHerramientasContract.java
@@ -17,12 +17,6 @@ public interface IBarraHerramientasContract {
 
         /**
          * Este metodo debe ser usado por la View para notificar al Presenter que el boton
-         * Refrescar ha sido pulsado.
-         */
-        void onRefreshClicked();
-
-        /**
-         * Este metodo debe ser usado por la View para notificar al Presenter que el boton
          * Convenios ha sido pulsado.
          */
         void onConveniosClicked();

--- a/AndroidProject/app/src/main/res/layout/activity_convenios_view.xml
+++ b/AndroidProject/app/src/main/res/layout/activity_convenios_view.xml
@@ -15,24 +15,40 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+
     <TextView
         android:id="@+id/tvConveniosVacio"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="16sp"
-        app:layout_constraintBottom_toBottomOf="@+id/lvConvenios"
-        app:layout_constraintEnd_toEndOf="@+id/lvConvenios"
-        app:layout_constraintStart_toStartOf="@+id/lvConvenios"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
-    <ListView
-        android:id="@+id/lvConvenios"
+        app:layout_constraintBottom_toBottomOf="@+id/swiperefreshConvenio"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        tools:text="TEXTO VACIO" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swiperefreshConvenio"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        app:layout_constraintVertical_bias="1.0">
+
+        <ListView
+            android:id="@+id/lvConvenios"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AndroidProject/app/src/main/res/layout/activity_historial_repostajes_view.xml
+++ b/AndroidProject/app/src/main/res/layout/activity_historial_repostajes_view.xml
@@ -14,15 +14,29 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/tvRepostajesVacios"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="16sp"
-        app:layout_constraintBottom_toBottomOf="@+id/lvHistoricoGasolineras"
-        app:layout_constraintEnd_toEndOf="@+id/lvHistoricoGasolineras"
-        app:layout_constraintStart_toStartOf="@+id/lvHistoricoGasolineras"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        tools:text="TEXTO VACIO" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/swiperefreshRepostaje"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"  >
 
     <ListView
         android:id="@+id/lvHistoricoGasolineras"
@@ -43,4 +57,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AndroidProject/app/src/main/res/layout/activity_main.xml
+++ b/AndroidProject/app/src/main/res/layout/activity_main.xml
@@ -15,6 +15,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/swiperefresh"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar" >
+
     <ListView
         android:id="@+id/lvGasolineras"
         android:layout_width="0dp"
@@ -24,5 +35,7 @@
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AndroidProject/app/src/main/res/menu/main_menu.xml
+++ b/AndroidProject/app/src/main/res/menu/main_menu.xml
@@ -12,7 +12,4 @@
     <item
         android:id="@+id/menuInfo"
         android:title="@string/info" />
-    <item
-        android:id="@+id/menuRefresh"
-        android:title="@string/refresh" />
 </menu>

--- a/AndroidProject/app/src/main/res/menu/main_menu_order.xml
+++ b/AndroidProject/app/src/main/res/menu/main_menu_order.xml
@@ -13,9 +13,6 @@
         android:id="@+id/menuInfo"
         android:title="@string/info" />
     <item
-        android:id="@+id/menuRefresh"
-        android:title="@string/refresh" />
-    <item
         android:id="@+id/menuDistancia"
         android:title="Ordenar distancia"
         android:icon="@drawable/location_32"

--- a/AndroidProject/app/src/main/res/values/strings.xml
+++ b/AndroidProject/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
 
     <string name="conveniosCampoMarca">Marca:</string>
     <string name="conveniosCampoDescuento">Descuento (%):</string>
-    <string name="conveniosListaVacia">La lista de convenios esta vacía</string>
+    <string name="conveniosListaVacia">La lista de convenios está vacía</string>
     <string name="conveniosFalloAccesoDatos">Ha ocurrido un error al acceder a los datos.</string>
     <string name="aceptar">Aceptar</string>
     <string name="reintentar">Reintentar</string>

--- a/AndroidProject/gradle.properties
+++ b/AndroidProject/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+android.enableJetifier=true


### PR DESCRIPTION
Se ha modificado la forma de llamar a la funcionalidad de refrescar la actividad mediante el gesto de deslizar hacia abajo. A su vez, se ha eliminado el anterior acceso mediante la opción dentro del menú de opciones en la esquina superior derecha.

Esta funcionalidad se puede llamar desde las vistas principal, de convenios y de repostajes.